### PR TITLE
chore: migrate dispose and observe

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,19 +1,19 @@
 {
-    "name": "Deno codespaces template",
-    "customizations": {
-        "vscode": {
-            "extensions": [
-                "github.copilot",
-                "gruntfuggly.todo-tree",
-                "denoland.vscode-deno"
-            ],
-            "settings": {
-                "files.exclude": {
-                    "**/CODE_OF_CONDUCT.md": true,
-                    "**/LICENSE": true
-                }
-            }
+  "name": "Deno codespaces template",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "github.copilot",
+        "gruntfuggly.todo-tree",
+        "denoland.vscode-deno"
+      ],
+      "settings": {
+        "files.exclude": {
+          "**/CODE_OF_CONDUCT.md": true,
+          "**/LICENSE": true
         }
-    },
-    "dockerFile": "Dockerfile"
+      }
+    }
+  },
+  "dockerFile": "Dockerfile"
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+name: CI
+
+on:
+  push:
+    branches: ["main", "dev"]
+  pull_request:
+    branches: ["main", "dev"]
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os: 
+          - ubuntu-22.04
+          - windows-2022
+          - macOS-12
+        deno: 
+          - v1.42.4
+          - v1.x
+
+    steps:
+      - name: Setup repo
+        uses: actions/checkout@v4
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: ${{ matrix.deno }}
+        
+      - name: Run tests
+        run: deno task test
+
+      - name: Generate coverage
+        run: deno task cov:gen
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4.0.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: kz-io/core
+        
+  cleanliness:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-22.04
+
+    steps:
+      - name: Setup repo
+        uses: actions/checkout@v4
+
+      - name: Install Deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.41.1
+
+      - name: Run formatter
+        run: deno fmt --check
+
+      - name: Run linter
+        run: deno lint

--- a/.github/workflows/jsr.yml
+++ b/.github/workflows/jsr.yml
@@ -1,0 +1,17 @@
+name: JSR
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - run: npx jsr publish
+      

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,10 @@ dev/
 dev.ts
 docs/
 test-dir/
+deno.lock
+cov.lcov
+coverage/
+.DS_Store
+.idea
+.vim
+**/cov/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,5 @@
   "deno.codeLens.test": true,
   "deno.enable": true,
   "deno.lint": true,
-  "typescript.suggest.completeFunctionCalls": true,
-  "typescript.suggest.autoImports": true,
+  "typescript.suggest.autoImports": true
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,148 @@
+# Contributing
+
+Thank you for your interest in contributing to the kz libraries. There
+are multiple ways to contribute, including reporting or resolving issues,
+requesting or adding new features, improving documentation, creating guides,
+adding translations, and more.
+
+## Found an issue?
+
+If you find an issue in a kz library source code, you can help by
+[submitting an issue][issues] to its GitHub Repository. If you have a fix for
+the issue, you can submit a Pull Request.
+
+## Want a feature?
+
+You can request a new feature in a library by [submitting an issue][feature] to
+a kz library's GitHub Repository. If you are unsure which library a
+feature should be requested in, you can [submit an issue][feature-new] on the
+`kz/please` repo.
+
+## What you need to know
+
+If you are interested in contributing with code, you only need to be familiar
+with [TypeScript][typescript] and [Deno][deno].
+
+You can contribute to documentation by looking at
+[documentation issues][documentation].
+
+# Making code contributions
+
+New to contributing to open source projects?
+
+Find an issue of interest, or a feature that you'd like to implement. You can
+use [the "good first issue" view][first-issue] to help ease into the project.
+
+## 1. Fork it
+
+Fork the repository to your GitHub organization. This means that you'll have a
+copy of the repository under _**username/repo-name**_.
+
+## 2. Clone it
+
+```bash
+git clone https://github.com/{username}/repo-name.git
+```
+
+## 3. Branch it
+
+Create a new branch for your fix or feature.
+
+```bash
+git checkout -b branch-name-here
+```
+
+## 4. Setup dev environment
+
+Set up the development environment:
+
+1. [Deno][deno] v1.20.x is installed.
+
+## 5. Do it
+
+Update the code with your issue fix or new feature implementation.
+
+## 6. Stage it
+
+Stage the changes to be committed:
+
+```bash
+git add .
+```
+
+## 7. Commit it
+
+Commit the changes with a brief message. (See
+[commit messages](#commit-messages) how to structure commit messages)
+
+```bash
+git commit -m "<type>: <description>"
+```
+
+## 8. Push it
+
+Push the changes.
+
+```bash
+git push origin branch-name-here
+```
+
+## 9. Create a pull request
+
+1. Create a pull request.
+   - Title the pull request and provide a brief summary of the changes made.
+   - Reference the issue the change is associated with.
+   - Explain the changes made, and any potential issues that may arise with the
+     pull request.
+2. Wait for the pull request to be reviewed.
+3. Make any changes recommended to the pull request.
+
+## Commit messages
+
+We follow the [Conventional Commits][conventional-commit] commit message
+convention. The patterns kz libraries do not have any scopes.
+
+Commit messages should be structured like this:
+
+```bash
+<type>: <description>
+```
+
+Example
+
+```
+fix: fix IPv4 CIDR-to-mask resolution on /32 masks.
+```
+
+### Types:
+
+- **chore**: Changes to the build process or auxiliary tools and libraries such
+  as documentation generation
+- **docs**: Documentation only changes
+- **feat**: A new feature
+- **fix**: A bug fix
+- **perf**: A code change that improves performance
+- **refactor**: A code change that neither fixes a bug nor adds a feature
+- **style**: Changes that do not affect the meaning of the code (white-space,
+  formatting, missing semi-colons, etc...)
+- **test**: Adding missing or correcting existing tests
+
+## Code of conduct
+
+Please note that this project is released with a Contributor Code of Conduct. By
+participating in this project you agree to abide by its terms.
+
+[Code of Conduct][code-of-conduct]
+
+Our Code of Conduct means that you are responsible for treating everyone on the
+project with respect and courtesy.
+
+[typescript]: https://www.typescriptlang.org/docs "TypeScript: The JavaScript superset for the future"
+[deno]: https://deno.land "Deno: A modern web platform for writing JavaScript"
+[conventional-commit]: https://www.conventionalcommits.org/en/v1.0.0/ "Conventional Commits: A guide to commit messages"
+[code-of-conduct]: https://github.com/kz-io/.github/blob/main/.github/CODE_OF_CONDUCT.md "Contributor Code of Conduct"
+[feature-new]: https://github.com/kz-io/please/issues/new?template=feature.yaml&title= "Request a new feature in kz"
+[issues]: https://github.com/kz-io/patterns/issues/new?template=issue.yaml&title= "Report an issue in kz/patterns"
+[feature]: https://github.com/kz-io/patterns/issues/new?template=feature.md&title= "Request a new feature in kz/patterns"
+[documentation]: https://github.com/kz-io/patterns/labels/type%3A%20docs "Documentation issues in kz/patterns"
+[first-issue]: https://github.com/kz-io/patterns/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22 "Good first issues in kz/patterns"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,81 @@
+<p align="center">
+<img alt="kz logo" height="48" src="https://raw.githubusercontent.com/i11n/.github/main/svg/kz/color/kz.svg" />
+<strong>patterns</strong>
+</p>
+
+<p align="center">
+kz is a collection of easy-to-use utility and feature libraries for creating anything you want with the <a href="https://deno.com">Deno</a> runtime.
+</p>
+
+<h1 align="center">@kz/patterns</h1>
+
+<p align="center">
+Provides types and base implementations of common design patterns.
+</p>
+
+<p align="center">
+<a href="https://jsr.io/@kz/patterns">Overview</a> |
+<a href="https://jsr.io/@kz/patterns/doc">API Docs</a>
+</p>
+
+## Examples
+
+<!-- TODO: Add examples for main module -->
+
+## Sub-modules
+
+## Contributing
+
+Contributions are welcome! Take a look at our [contributing guidelines][contributing] to get started.
+
+<p align="center">
+<a href="https://github.com/i11n/.github/blob/main/.github/CODE_OF_CONDUCT.md">
+  <img alt="Contributor Covenant" src="https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg?style=flat-square" />
+</a>
+</p>
+
+## License
+
+The MIT License (MIT) 2020-2024 integereleven. Refer to [LICENSE][license] for details.
+
+<p align="center">
+<sub>Built with ❤ by integereleven</sub>
+</p>
+
+<p align="center">
+<img
+  alt="kz.io logo"
+  height="64"
+  src="https://raw.githubusercontent.com/i11n/.github/main/svg/brand/color/open-stroke.svg"
+/>
+</p>
+
+<p align="center">
+<a href="https://github.com/kz-io/patterns/commits">
+  <img alt="GitHub commit activity" src="https://img.shields.io/github/commit-activity/m/kz-io/patterns?style=flat-square">
+</a>
+<a href="https://github.com/kz-io/patterns/issues">
+  <img alt="GitHub issues" src="https://img.shields.io/github/issues-raw/kz-io/patterns?style=flat-square">
+</a>
+<a href="https://codecov.io/gh/kz-io/patterns" >
+  <img src="https://codecov.io/gh/kz-io/patterns/graph/badge.svg?token=TH8uOvl1sk"/>
+</a>
+</p>
+
+<p align="center">
+<a href="https://jsr.io/@kz/patterns">
+  <img src="https://jsr.io/badges/@kz/patterns" alt="" />
+</a>
+<a href="https://jsr.io/@kz/patterns">
+  <img src="https://jsr.io/badges/@kz/patterns/spatterns" alt="" />
+</a>
+</p>
+
+[deno]: https://deno.dom "Deno homepage"
+[jsr]: https://jsr.io "JSR homepage"
+[branches]: https://github.com/kz-io/patterns/branches "@kz/patterns branches on GitHub"
+[releases]: https://github.com/kz-io/patterns/releases "@kz/patterns releases on GitHub"
+[contributing]: https://github.com/kz-io/patterns/blob/main/CONTRIBUTING.md "@kz/patterns contributing guidelines"
+[license]: https://github.com/kz-io/patterns/blob/main/LICENSE "@kz/patterns license"
+
+<!-- TODO: Update with links to modules on jsr -->

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,4 +1,10 @@
 {
+  "name": "@kz/patterns",
+  "version": "0.0.1",
+  "exports": {
+    "./dispose": "./dispose/mod.ts",
+    "./observe": "./observe/mod.ts"
+  },
   "lint": {
     "rules": {
       "tags": [
@@ -23,16 +29,39 @@
     "semiColons": true
   },
   "tasks": {
-    "init": "deno run -A https://denopkg.com/kz-io/pkgsvc@dev/public/init.ts",
     "fmt": "deno fmt",
     "lint": "deno lint",
-    "test": "deno test",
-    "docs": "deno doc --json ./mod.ts > _docs.json",
-    // "bump-version": "deno run -A https://denopkg.com/partic11e/repo-svc/cli/bump_version.ts",
-    // "add-exception": "deno run -A https://denopkg.com/partic11e/repo-svc/cli/add_exception.ts",
-    // "add-feature": "deno run -A https://denopkg.com/partic11e/repo-svc/cli/add_feature.ts",
-    // "commit": "deno task pre-commit && deno run -A https://denopkg.com/partic11e/repo-svc/cli/commit.ts",
-    "pre-commit": "deno task test && deno task lint && deno task fmt && deno task docs",
-    "cache": "deno cache --reload --lock=lock.json --lock-write deps.ts"
+    "test": "deno test --allow-all --coverage --doc --trace-leaks",
+    "cov": "deno task test && deno task cov:gen && deno task cov:report",
+    "cov:gen": "deno coverage coverage --lcov --output=cov.lcov",
+    "cov:report": "deno coverage --html coverage",
+    "docs": "deno doc --html --name=@kz/patterns ./dispose/mod.ts ./observe/mod.ts",
+    "jsr:check": "deno publish --dry-run --allow-dirty",
+    "pre-commit": "deno task lint && deno task fmt && deno task cov && deno task docs && deno task jsr:check"
+  },
+  "imports": {
+    "@std/assert": "jsr:@std/assert@^0.221.0",
+    "@std/testing": "jsr:@std/testing@^0.221.0",
+    "@kz/core/exceptions": "https://denopkg.com/kz-io/core@dev/exceptions/mod.ts"
+  },
+  "exclude": [
+    ".git",
+    "cov",
+    "coverage",
+    "testdata",
+    "docs"
+  ],
+  "publish": {
+    "include": [
+      "README.md",
+      "LICENSE",
+      "mod.ts",
+      "**/*.ts",
+      "deno.json",
+      "deno.lock"
+    ],
+    "exclude": [
+      "**/*.test.ts"
+    ]
   }
 }

--- a/dispose/_internal/dispose_internal.test.ts
+++ b/dispose/_internal/dispose_internal.test.ts
@@ -1,0 +1,49 @@
+/**
+ * @copyright 2020-2024 integereleven. All rights reserved. MIT license.
+ * @file This file tests the disposeInternal internal function.
+ */
+
+import { describe, it } from '@std/testing/bdd';
+import { assert } from '@std/assert';
+
+import { AbstractDisposable } from '../mod.ts';
+import { disposeInternal } from './mod.ts';
+
+describe('disposeInternal', () => {
+  describe('disposeInternal(...disposables)', () => {
+    it('should dispose all disposables', () => {
+      class Disposable extends AbstractDisposable {
+      }
+
+      const a = new Disposable();
+      const b = new Disposable();
+      const c = new Disposable();
+
+      const exceptions = disposeInternal([a, b, c]);
+
+      assert(exceptions === undefined);
+    });
+    it('should return any errors', () => {
+      class Disposable extends AbstractDisposable {
+        constructor(private throwOnDispose = false) {
+          super();
+        }
+
+        protected onDispose(): void {
+          if (this.throwOnDispose) throw new Error('Dispose failed');
+
+          super.onDispose();
+        }
+      }
+
+      const a = new Disposable();
+      const b = new Disposable(true);
+      const c = new Disposable(true);
+
+      const exceptions = disposeInternal([a, b, c]);
+
+      assert(exceptions !== undefined);
+      assert(exceptions.length === 2);
+    });
+  });
+});

--- a/dispose/_internal/dispose_internal.ts
+++ b/dispose/_internal/dispose_internal.ts
@@ -1,0 +1,96 @@
+/**
+ * @copyright 2020-2024 integereleven. All rights reserved. MIT license.
+ * @file This file exports the disposeInternal internal function.
+ */
+
+import type { Exception } from '@kz/core/exceptions';
+import type { IDisposable } from '../types/mod.ts';
+
+/**
+ * Disposes an array of {@link IDisposable} objects, returning any exceptions that may have occurred during disposal.
+ *
+ * @param disposables - The array of {@link IDisposable} objects to dispose.
+ * @returns An array of exceptions that occurred during disposal, if any.
+ *
+ * @example Good disposal
+ * ```ts
+ * import { assert } from '@std/assert';
+ * import { disposeInternal } from './dispose_internal.ts';
+ * import { AbstractDisposable } from '../abstract_disposable.ts';
+ *
+ * class Disposable extends AbstractDisposable {
+ *   protected onDispose() {
+ *     console.log('Disposed');
+ *   }
+ * }
+ *
+ * const a = new Disposable();
+ * const b = new Disposable();
+ * const c = new Disposable();
+ *
+ * const exceptions = disposeInternal([a, b, c]);
+ *
+ * assert(exceptions === undefined);
+ * ```
+ *
+ * @example Bad disposal
+ * ```ts
+ * import { assert } from '@std/assert';
+ * import { disposeInternal } from './dispose_internal.ts';
+ * import { AbstractDisposable } from '../abstract_disposable.ts';
+ *
+ * class Disposable extends AbstractDisposable {
+ *   constructor(private throwOnDispose = false) {
+ *     super();
+ *    }
+ *
+ *   protected onDispose() {
+ *    if (this.throwOnDispose) throw new Error('Dispose failed');
+ *     console.log('Disposed');
+ *   }
+ * }
+ *
+ * const a = new Disposable();
+ * const b = new Disposable(true);
+ * const c = new Disposable();
+ *
+ * const exceptions = disposeInternal([a, b, c]);
+ *
+ * assert(exceptions !== undefined);
+ * assert(exceptions.length === 1);
+ * ```
+ */
+export function disposeInternal(
+  disposables: IDisposable[],
+): (Error | Exception)[] | undefined {
+  const exceptions: (Error | Exception)[] = [];
+
+  for (let i = 0; i < disposables.length; i++) {
+    const disposable = disposables[i];
+    const ex = disposeInternalOne(disposable);
+
+    if (ex) exceptions.push(ex);
+
+    continue;
+  }
+
+  return exceptions.length ? exceptions : undefined;
+}
+
+/**
+ * Disposes an {@link IDisposable} object, returning the exception that occurred, if any, during disposal.
+ *
+ * @param disposable - The {@link IDisposable} object to dispose.
+ * @returns The exception that occurred during disposal, if any.
+ */
+function disposeInternalOne(
+  disposable: IDisposable,
+): Error | Exception | undefined {
+  try {
+    disposable.dispose();
+
+    return;
+  } catch (err) {
+    return err;
+  }
+}

--- a/dispose/_internal/mod.ts
+++ b/dispose/_internal/mod.ts
@@ -1,0 +1,6 @@
+/**
+ * @copyright 2020-2024 integereleven. All rights reserved. MIT license.
+ * @file Exports module-internal symbols.
+ */
+
+export { disposeInternal } from './dispose_internal.ts';

--- a/dispose/abstract_disposable.test.ts
+++ b/dispose/abstract_disposable.test.ts
@@ -1,0 +1,84 @@
+/**
+ * @copyright 2020-2024 integereleven. All rights reserved. MIT license.
+ * @file This file tests the AbstractDisposable class.
+ */
+
+import { describe, it } from '@std/testing/bdd';
+import { assertSpyCalls, spy } from '@std/testing/mock';
+import { assertEquals, assertThrows } from '@std/assert';
+
+import { AbstractDisposable } from './mod.ts';
+
+class Fibonacci extends AbstractDisposable {
+  #items: number[] = [0, 1];
+
+  constructor(itemCount: number) {
+    super();
+
+    const itemLength = this.#items.length;
+
+    if (itemCount > this.#items.length) {
+      for (let i = 0; i < (itemCount - itemLength); i++) {
+        const [a, b] = this.#items.slice(-2);
+
+        this.#items.push(a + b);
+      }
+    }
+  }
+
+  public get sequence(): number[] {
+    return [...this.#items];
+  }
+
+  public get count(): number {
+    return this.#items.length;
+  }
+
+  public continueSequence(itemCount: number): void {
+    this.assertNotDisposed();
+
+    for (let i = 0; i < itemCount; i++) {
+      const [a, b] = this.#items.slice(-2);
+
+      this.#items.push(a + b);
+    }
+  }
+
+  public disposing(): void {
+    console.log('Disposing Fibonacci');
+  }
+
+  protected onDispose(): void {
+    this.disposing();
+    this.#items = [];
+    super.onDispose();
+  }
+}
+
+describe('AbstractDisposable', () => {
+  const fib = new Fibonacci(6);
+  const spyDisposing = spy(fib, 'disposing');
+
+  it('tests all', () => {
+    assertEquals(fib.count, 6);
+    assertEquals(fib.isDisposed, false);
+    assertEquals(`${fib}`, '[object Fibonacci{isDisposed: false}]');
+
+    fib.continueSequence(5);
+    assertEquals(fib.count, 11);
+    assertEquals(fib.isDisposed, false);
+    assertEquals(`${fib}`, '[object Fibonacci{isDisposed: false}]');
+
+    fib.dispose();
+
+    assertEquals(`${fib}`, '[object Fibonacci{isDisposed: true}]');
+    assertSpyCalls(spyDisposing, 1);
+    assertThrows(() => fib.continueSequence(5));
+    assertEquals(fib.count, 0);
+    assertEquals(fib.isDisposed, true);
+
+    fib.dispose();
+    assertEquals(fib.count, 0);
+    assertEquals(fib.isDisposed, true);
+  });
+});

--- a/dispose/abstract_disposable.ts
+++ b/dispose/abstract_disposable.ts
@@ -1,0 +1,167 @@
+/**
+ * @copyright 2020-2024 integereleven. All rights reserved. MIT license.
+ * @file This file exports the AbstractDisposable abstract class.
+ */
+
+import { assertNotDisposed } from './assert_not_disposed.ts';
+
+import type { IDisposable } from './types/mod.ts';
+
+/**
+ * An abstract class implementation of the {@link IDisposable} interface.
+ *
+ * @example Example using fibonacci sequence
+ * ```ts
+ * import { assert, assertEquals } from '@std/assert';
+ * import { AbstractDisposable } from './abstract_disposable.ts';
+ * import { ObjectDisposedException } from './exceptions/object_disposed_exception.ts';
+ *
+ * class Fibonacci extends AbstractDisposable {
+ *   private _a = 0;
+ *   private _b = 1;
+ *   private _items = [this._a, this._b];
+ *
+ *   public get sequence(): number[] {
+ *     return [...this._items];
+ *   }
+ *
+ *   public continueSequence(itemCount: number): void {
+ *     this.assertNotDisposed();
+ *
+ *     for (let i = 0; i < itemCount; i++) {
+ *       const [a, b] = this._items.slice(-2);
+ *
+ *       this._items.push(a + b);
+ *     }
+ *   }
+ *
+ *   protected onDispose(): void {
+ *     this._items = [];
+ *     super.onDispose();
+ *   }
+ * }
+ *
+ * const fib = new Fibonacci();
+ *
+ * fib.continueSequence(6);
+ *
+ * assertEquals(fib.sequence.length, 8);
+ *
+ * fib.dispose();
+ *
+ * assertEquals(fib.sequence.length, 0);
+ *
+ * try {
+ *   fib.continueSequence(6);
+ * } catch (e) {
+ *   assert(e instanceof ObjectDisposedException);
+ * }
+ * ```
+ */
+export abstract class AbstractDisposable implements IDisposable {
+  /**
+   * Whether the resource for this `AbstractDisposable` have been freed up.
+   */
+  protected _isDisposed: boolean = false;
+
+  /**
+   * Asserts that an {@link IDisposable} instance has not been disposed, optionally with a specific message.
+   *
+   * @param disposable - The object to check.
+   * @param message - The message to include in the exception, if thrown.
+   * @throws {ObjectDisposedException} If the object is disposed.
+   *
+   * @example
+   * ```ts
+   * import { assertThrows } from '@std/assert';
+   * import type { IDisposable } from './types/interfaces.ts';
+   * import { AbstractDisposable } from './abstract_disposable.ts';
+   *
+   * const disposable: IDisposable = {
+   *   isDisposed: true,
+   *   dispose() {
+   *     this.isDisposed = true;
+   *   }
+   * };
+   *
+   * assertThrows(() => AbstractDisposable.assertNotDisposed(disposable));
+   * ```
+   */
+  public static assertNotDisposed(
+    disposable: IDisposable,
+    message?: string,
+  ): void {
+    assertNotDisposed(disposable, message);
+  }
+
+  /**
+   * Whether the resource for this `AbstractDisposable` have been freed up.
+   */
+  public get isDisposed(): boolean {
+    return this._isDisposed;
+  }
+
+  /**
+   * Returns the string representation of this `AbstractDisposable`.
+   *
+   * @example
+   * ```ts
+   * import { assertEquals } from '@std/assert';
+   * import { AbstractDisposable } from './abstract_disposable.ts';
+   *
+   * class Disposable extends AbstractDisposable { }
+   *
+   * const disposable = new Disposable();
+   *
+   * assertEquals(`${disposable}`, '[object Disposable{isDisposed: false}]');
+   * ```
+   */
+  public toString(): string {
+    const { isDisposed, constructor } = this;
+    return `[object ${constructor.name}{isDisposed: ${isDisposed}}]`;
+  }
+
+  /**
+   * Initiates the process of freeing up unmanaged resources and finalizing this `AbstractDisposable`.
+   *
+   * @example
+   * ```ts
+   * import { assertEquals } from '@std/assert';
+   * import { AbstractDisposable } from './abstract_disposable.ts';
+   *
+   * class Disposable extends AbstractDisposable { }
+   *
+   * const disposable = new Disposable();
+   *
+   * assertEquals(disposable.isDisposed, false);
+   *
+   * disposable.dispose();
+   *
+   * assertEquals(disposable.isDisposed, true);
+   * ```
+   */
+  public dispose(): void {
+    if (this.isDisposed) return;
+
+    try {
+      this.onDispose();
+    } finally {
+      this._isDisposed = true;
+    }
+  }
+
+  /**
+   * Asserts that this `AbstractDisposable` has not been disposed, optionally with a specific message.
+   *
+   * @param message - The message to include in the exception, if thrown.
+   * @throws {ObjectDisposedException} If this `AbstractDisposable` has been disposed.
+   */
+  protected assertNotDisposed(message?: string): void {
+    AbstractDisposable.assertNotDisposed(this, message);
+  }
+
+  /**
+   * Frees up resources.
+   */
+  protected onDispose(): void {}
+}

--- a/dispose/assert_not_disposed.test.ts
+++ b/dispose/assert_not_disposed.test.ts
@@ -1,0 +1,25 @@
+/**
+ * @copyright 2020-2024 integereleven. All rights reserved. MIT license.
+ * @file This file tests the assertNotDisposed function.
+ */
+
+import { describe, it } from '@std/testing/bdd';
+import { assertThrows } from '@std/assert';
+
+import { assertNotDisposed } from './mod.ts';
+
+describe('assertNotDisposed', () => {
+  describe('(disposable)', () => {
+    it('should throw if the object is disposed', () => {
+      const disposable = { isDisposed: true, dispose(): void {} };
+      assertThrows(() => assertNotDisposed(disposable));
+    });
+  });
+
+  describe('(disposable, message)', () => {
+    it('should throw if the object is disposed', () => {
+      const disposable = { isDisposed: true, dispose(): void {} };
+      assertThrows(() => assertNotDisposed(disposable, 'Object is disposed.'));
+    });
+  });
+});

--- a/dispose/assert_not_disposed.ts
+++ b/dispose/assert_not_disposed.ts
@@ -1,0 +1,47 @@
+/**
+ * @copyright 2020-2024 integereleven. All rights reserved. MIT license.
+ * @file This file exports the assertNotDisposed function.
+ */
+
+import { ObjectDisposedException } from './exceptions/mod.ts';
+
+import type { IDisposable } from './types/mod.ts';
+
+/**
+ * Asserts that the specified object is not disposed, optionally with a specific message.
+ *
+ * @param disposable - The object to check.
+ * @param message - The message to include in the exception, if thrown.
+ * @throws {ObjectDisposedException} If the object is disposed.
+ *
+ * @example
+ * ```ts
+ * import { assertThrows } from '@std/assert';
+ * import type { IDisposable } from './types/interfaces.ts';
+ * import { assertNotDisposed } from './assert_not_disposed.ts';
+ *
+ * const disposable: IDisposable = {
+ *   isDisposed: true,
+ *   dispose() {
+ *     this.isDisposed = true;
+ *   }
+ * };
+ *
+ * assertThrows(() => assertNotDisposed(disposable));
+ * ```
+ */
+export function assertNotDisposed(
+  disposable: IDisposable,
+  message?: string,
+): void {
+  if (disposable.isDisposed) {
+    const objectName = disposable.constructor.name;
+    const exception = message
+      ? new ObjectDisposedException(message, {
+        objectName,
+      })
+      : new ObjectDisposedException({ objectName });
+
+    throw exception;
+  }
+}

--- a/dispose/disposable_pool.test.ts
+++ b/dispose/disposable_pool.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @copyright 2020-2024 integereleven. All rights reserved. MIT license.
+ * @file This file tests the DisposablePool class.
+ */
+
+import { describe, it } from '@std/testing/bdd';
+import { assert, assertEquals } from '@std/assert';
+
+import { DisposablePool, type IDisposable } from './mod.ts';
+
+class Basic implements IDisposable {
+  constructor(public name: string) {}
+
+  isDisposed = false;
+
+  dispose(): void {
+    this.isDisposed = true;
+  }
+}
+
+class Async implements IDisposable {
+  constructor(public name: string) {}
+
+  isDisposed = false;
+
+  async run(): Promise<void> {
+    await new Promise(function (resolve): void {
+      setTimeout(resolve, 1000);
+    });
+  }
+
+  dispose(): void {
+    this.isDisposed = true;
+  }
+}
+
+describe('DisposablePool', () => {
+  describe('(resources)', () => {
+    it('should create a new instance with undisposed .resources', () => {
+      const pool = new DisposablePool({
+        a: new Basic('A'),
+        b: new Basic('B'),
+        c: new Basic('C'),
+      });
+      assert(!pool.isDisposed);
+      assert(!pool.resources?.a.isDisposed);
+      assert(!pool.resources?.b.isDisposed);
+      assert(!pool.resources?.c.isDisposed);
+    });
+  });
+
+  describe('use(callback)', () => {
+    const pool = new DisposablePool({
+      a: new Basic('A'),
+      b: new Basic('B'),
+      c: new Basic('C'),
+    });
+
+    it('pool and resource undisposed', () => {
+      pool.use(({ a, b, c }, p) => {
+        assert(!p.isDisposed);
+        assert(!a.isDisposed);
+        assert(!b.isDisposed);
+        assert(!c.isDisposed);
+      });
+    });
+
+    it('should dispose after callback', () => {
+      assert(pool.isDisposed);
+      assertEquals(pool.resources, undefined);
+    });
+  });
+
+  describe('useAsync(callback)', () => {
+    const pool = new DisposablePool({
+      a: new Async('A'),
+      b: new Async('B'),
+      c: new Async('C'),
+    });
+
+    it('pool and resource undisposed', async () => {
+      await pool.useAsync(async ({ a, b, c }, p) => {
+        assert(!p.isDisposed);
+        assert(!a.isDisposed);
+        assert(!b.isDisposed);
+        assert(!c.isDisposed);
+
+        await a.run();
+        await b.run();
+        await c.run();
+      });
+    });
+
+    it('should dispose after callback', () => {
+      assert(pool.isDisposed);
+    });
+  });
+});

--- a/dispose/disposable_pool.ts
+++ b/dispose/disposable_pool.ts
@@ -1,0 +1,144 @@
+/**
+ * @copyright 2020-2024 integereleven. All rights reserved. MIT license.
+ * @file This file exports the DisposablePool class.
+ */
+
+import { AbstractDisposable } from './abstract_disposable.ts';
+import { dispose } from './dispose.ts';
+
+import type { IDisposable } from './types/mod.ts';
+
+/**
+ * A class for collecting independant {@link IDisposable} objects into a single `DisposablePool`.
+ *
+ * @example
+ * ```ts
+ * import { assert } from '@std/assert';
+ * import { DisposablePool } from './disposable_pool.ts';
+ * import type { IDisposable } from './types/interfaces.ts';
+ *
+ * class Async implements IDisposable {
+ *   constructor(public name: string) {}
+ *
+ *   isDisposed = false;
+ *
+ *   async run(): Promise<void> {
+ *     await new Promise(function (resolve): void {
+ *       setTimeout(resolve, 1000);
+ *     });
+ *   }
+ *
+ *   dispose(): void {
+ *     this.isDisposed = true;
+ *   }
+ * }
+ *
+ * const pool = new DisposablePool({
+ *   a: new Async('A'),
+ *   b: new Async('B'),
+ *   c: new Async('C'),
+ * });
+ *
+ * pool.useAsync(async ({ a, b, c }, p) => {
+ *   await a.run();
+ *   await b.run();
+ *   await c.run();
+ *
+ *   assert(a.isDisposed);
+ *   assert(b.isDisposed);
+ *   assert(c.isDisposed);
+ * });
+ *
+ * assert(pool.isDisposed);
+ * ```
+ */
+export class DisposablePool<T extends { [key: string]: IDisposable }>
+  extends AbstractDisposable {
+  /**
+   * Creates a new instance of DisposablePool, with the keyed collection of {@link IDisposable} objects to pool together.
+   *
+   * @param disposables - The keyed collection of {@link IDisposable} objects to pool together.
+   */
+  constructor(disposables: T) {
+    super();
+
+    this._disposables = disposables;
+  }
+
+  /**
+   * The resources within the DisposablePool.
+   */
+  public get resources(): T | undefined {
+    return this._disposables ? { ...this._disposables } : undefined;
+  }
+
+  /**
+   * A convenience method to use the pool of {@link IDisposable} objects in a callback, disposing of the pool and this DisposablePool on completion.
+   *
+   * @param callback - The function to perform with the pool of {@link IDisposable} objects.
+   * @returns The result of the callback function.
+   */
+  public use<R>(callback: (disposables: T, self: this) => void): this {
+    this.assertNotDisposed();
+
+    const { resources } = this;
+
+    try {
+      if (resources) {
+        callback(resources, this);
+      }
+    } finally {
+      this.dispose();
+    }
+
+    return this;
+  }
+
+  /**
+   * A convenience method to use the pool of {@link IDisposable} objects in a callback, disposing of the pool and this DisposablePool on completion.
+   *
+   * @param callback - The function to perform with the pool of {@link IDisposable} objects.
+   * @returns The result of the callback function.
+   */
+  public async useAsync<R>(
+    callback: (disposables: T, self: this) => Promise<void>,
+  ): Promise<this> {
+    this.assertNotDisposed();
+
+    const { resources } = this;
+
+    try {
+      if (resources) {
+        await callback(resources, this);
+      }
+    } finally {
+      this.dispose();
+    }
+
+    return this;
+  }
+
+  /**
+   * The pool of {@link IDisposable} objects.
+   */
+  protected _disposables: T | undefined;
+
+  /**
+   * Disposes the pool of {@link IDisposable} objects, then disposes this DisposablePool.
+   *
+   * @returns An array of exceptions that occurred during disposal, if any.
+   */
+  protected onDispose(): void {
+    this.assertNotDisposed();
+
+    const { resources } = this;
+
+    if (resources) {
+      Object.keys(resources).forEach((key) => {
+        dispose(resources[key]);
+      });
+    }
+
+    this._disposables = undefined;
+  }
+}

--- a/dispose/dispose.test.ts
+++ b/dispose/dispose.test.ts
@@ -1,0 +1,53 @@
+/**
+ * @copyright 2020-2024 integereleven. All rights reserved. MIT license.
+ * @file This file tests the dispose function.
+ */
+
+import { describe, it } from '@std/testing/bdd';
+import { assert } from '@std/assert';
+
+import { dispose } from './mod.ts';
+
+describe('dispose', () => {
+  describe('(...disposables)', () => {
+    it('should dispose all disposables', () => {
+      const disposable = {
+        dispose(): void {
+          this.isDisposed = true;
+        },
+        isDisposed: false,
+      };
+
+      dispose(disposable);
+
+      assert(disposable.isDisposed);
+    });
+
+    it('should return undefined if all disposables are disposed', () => {
+      const disposable = {
+        dispose(): void {
+          this.isDisposed = true;
+        },
+        isDisposed: false,
+      };
+
+      const exceptions = dispose(disposable);
+
+      assert(exceptions === undefined);
+    });
+
+    it('should return an array of exceptions if any disposables throw', () => {
+      const disposable = {
+        dispose(): void {
+          throw new Error('Dispose failed');
+        },
+        isDisposed: false,
+      };
+
+      const exceptions = dispose(disposable);
+
+      assert(exceptions !== undefined);
+      assert(exceptions.length === 1);
+    });
+  });
+});

--- a/dispose/dispose.ts
+++ b/dispose/dispose.ts
@@ -1,0 +1,41 @@
+/**
+ * @copyright 2020-2024 integereleven. All rights reserved. MIT license.
+ * @file This file exports the dispose function.
+ */
+
+import { disposeInternal } from './_internal/mod.ts';
+
+import type { Exception } from '@kz/core/exceptions';
+import type { IDisposable } from './types/mod.ts';
+
+/**
+ * Disposes an array of {@link IDisposable} objects returning any exceptions that may have occrred during disposal.
+ *
+ * @param disposables - The array of {@link IDisposable} objects to dispose.
+ * @returns An array of exceptions that occurred during disposal, if any.
+ *
+ * @example
+ * ```ts
+ * import { assert } from '@std/assert';
+ * import { dispose } from './dispose.ts';
+ * import type { IDisposable } from './types/interfaces.ts';
+ *
+ * const disposable: IDisposable = {
+ *    dispose(): void {
+ *     this.isDisposed = true;
+ *   },
+ *   isDisposed: false,
+ * };
+ *
+ * assert(!disposable.isDisposed);
+ *
+ * dispose(disposable);
+ *
+ * assert(disposable.isDisposed);
+ * ```
+ */
+export function dispose(
+  ...disposables: IDisposable[]
+): (Error | Exception)[] | undefined {
+  return disposeInternal(disposables);
+}

--- a/dispose/exceptions/mod.ts
+++ b/dispose/exceptions/mod.ts
@@ -1,0 +1,9 @@
+/**
+ * @copyright 2020-2024 integereleven. All rights reserved. MIT license.
+ * @file Exports exceptions and related symbols for the module.
+ */
+
+export {
+  ObjectDisposedException,
+  type ObjectDisposedExceptionData,
+} from './object_disposed_exception.ts';

--- a/dispose/exceptions/object_disposed_exception.test.ts
+++ b/dispose/exceptions/object_disposed_exception.test.ts
@@ -1,0 +1,191 @@
+/**
+ * @copyright 2020-2024 integereleven. All rights reserved. MIT license.
+ * @file This file tests the ObjectDisposedException class and its related exception data type.
+ */
+
+import { describe, it } from '@std/testing/bdd';
+import {
+  assertEquals,
+  assertInstanceOf,
+  assertStringIncludes,
+} from '@std/assert';
+
+import { Exception, InvalidException } from '@kz/core/exceptions';
+
+import {
+  ObjectDisposedException,
+  type ObjectDisposedExceptionData,
+} from './mod.ts';
+
+describe('ObjectDisposedException', () => {
+  const CODE = 64;
+  const NAME = 'ObjectDisposedException';
+  const DEF_MSG = 'An operation was attempted on a disposed object.';
+  const URI_BASE = `0x${CODE.toString(16)}`;
+
+  describe('inheritance', () => {
+    const exc = new ObjectDisposedException('An error occurred.');
+    it('should extend the Error, Exception, and InvalidException class', () => {
+      assertInstanceOf(exc, InvalidException);
+      assertInstanceOf(exc, Exception);
+      assertInstanceOf(exc, Error);
+    });
+  });
+
+  describe('new(message)', () => {
+    const MSG = 'An object is disposed, but an operation was attempted.';
+    const STR = `${NAME}: ${MSG}`;
+    const CAUSE = undefined;
+    const DATA = undefined;
+    const URL = `${URI_BASE}?message=${encodeURIComponent(MSG)}`;
+
+    const exc = new ObjectDisposedException(MSG);
+
+    it('should create a new ObjectDisposedException instance with the specified message description', () => {
+      assertInstanceOf(exc, ObjectDisposedException);
+      assertInstanceOf(exc, Error);
+      assertEquals(exc.message, MSG);
+      assertEquals(exc.name, NAME);
+      assertEquals(exc.code, CODE);
+      assertEquals(exc.toString(), STR);
+      assertEquals(`${exc}`, STR);
+      assertEquals(exc.valueOf(), CODE);
+      assertEquals(+exc, CODE);
+      assertStringIncludes(exc.helpUrl, URL);
+      assertEquals(exc.cause, CAUSE);
+      assertEquals(exc.data, DATA);
+    });
+  });
+
+  describe('new(data)', () => {
+    const DATA: ObjectDisposedExceptionData = { objectName: 'foo' };
+    const MSG =
+      `An operation was attempted on a disposed object, ${DATA.objectName}.`;
+    const STR = `${NAME}: ${MSG}`;
+    const CAUSE = undefined;
+    const URL = `${URI_BASE}?message=${encodeURIComponent(MSG)}&data=${
+      encodeURIComponent(JSON.stringify(DATA))
+    }`;
+
+    const exc = new ObjectDisposedException(DATA);
+
+    it('should create a new ObjectDisposedException instance with the specified data', () => {
+      assertInstanceOf(exc, ObjectDisposedException);
+      assertInstanceOf(exc, Error);
+      assertEquals(exc.message, MSG);
+      assertEquals(exc.name, NAME);
+      assertEquals(exc.code, CODE);
+      assertEquals(exc.toString(), STR);
+      assertEquals(`${exc}`, STR);
+      assertEquals(exc.valueOf(), CODE);
+      assertEquals(+exc, CODE);
+      assertStringIncludes(exc.helpUrl, URL);
+      assertEquals(exc.cause, CAUSE);
+      assertEquals(exc.data, DATA);
+    });
+  });
+
+  describe('new(message, data)', () => {
+    const MSG = 'An object is disposed, but an operation was attempted.';
+    const DATA: ObjectDisposedExceptionData = { objectName: 'foo' };
+    const STR = `${NAME}: ${MSG}`;
+    const CAUSE = undefined;
+    const URL = `${URI_BASE}?message=${encodeURIComponent(MSG)}&data=${
+      encodeURIComponent(JSON.stringify(DATA))
+    }`;
+
+    const exc = new ObjectDisposedException(MSG, DATA);
+
+    it('should create a new ObjectDisposedException instance with the specified message description and additional, relevant data', () => {
+      assertInstanceOf(exc, ObjectDisposedException);
+      assertInstanceOf(exc, Error);
+      assertEquals(exc.message, MSG);
+      assertEquals(exc.name, NAME);
+      assertEquals(exc.code, CODE);
+      assertEquals(exc.toString(), STR);
+      assertEquals(`${exc}`, STR);
+      assertEquals(exc.valueOf(), CODE);
+      assertEquals(+exc, CODE);
+      assertStringIncludes(exc.helpUrl, URL);
+      assertEquals(exc.cause, CAUSE);
+      assertEquals(exc.data, DATA);
+    });
+  });
+
+  describe('new(message) - empty string', () => {
+    const MSG = DEF_MSG;
+    const STR = `${NAME}: ${MSG}`;
+    const CAUSE = undefined;
+    const DATA = undefined;
+    const URL = `${URI_BASE}?message=${encodeURIComponent(MSG)}`;
+
+    const exc = new ObjectDisposedException('');
+
+    it('should create a new ObjectDisposedException instance with the default message description', () => {
+      assertInstanceOf(exc, ObjectDisposedException);
+      assertInstanceOf(exc, Error);
+      assertEquals(exc.message, MSG);
+      assertEquals(exc.name, NAME);
+      assertEquals(exc.code, CODE);
+      assertEquals(exc.toString(), STR);
+      assertEquals(`${exc}`, STR);
+      assertEquals(exc.valueOf(), CODE);
+      assertEquals(+exc, CODE);
+      assertStringIncludes(exc.helpUrl, URL);
+      assertEquals(exc.cause, CAUSE);
+      assertEquals(exc.data, DATA);
+    });
+  });
+
+  describe('new(data) - empty object', () => {
+    const DATA = undefined;
+    const MSG = DEF_MSG;
+    const STR = `${NAME}: ${MSG}`;
+    const CAUSE = undefined;
+    const URL = `${URI_BASE}?message=${encodeURIComponent(MSG)}`;
+
+    const exc = new ObjectDisposedException({});
+
+    it('should create a new ObjectDisposedException instance with the default message description', () => {
+      assertInstanceOf(exc, ObjectDisposedException);
+      assertInstanceOf(exc, Error);
+      assertEquals(exc.message, MSG);
+      assertEquals(exc.name, NAME);
+      assertEquals(exc.code, CODE);
+      assertEquals(exc.toString(), STR);
+      assertEquals(`${exc}`, STR);
+      assertEquals(exc.valueOf(), CODE);
+      assertEquals(+exc, CODE);
+      assertStringIncludes(exc.helpUrl, URL);
+      assertEquals(exc.cause, CAUSE);
+      assertEquals(exc.data, DATA);
+    });
+  });
+
+  describe('new(data) - irrelevant data', () => {
+    const MSG = DEF_MSG;
+    const DATA: ObjectDisposedExceptionData = { foo: 'bar' };
+    const STR = `${NAME}: ${MSG}`;
+    const CAUSE = undefined;
+    const URL = `${URI_BASE}?message=${encodeURIComponent(MSG)}&data=${
+      encodeURIComponent(JSON.stringify(DATA))
+    }`;
+
+    const exc = new ObjectDisposedException(DATA);
+
+    it('should create a new ObjectDisposedException instance with the default message description', () => {
+      assertInstanceOf(exc, ObjectDisposedException);
+      assertInstanceOf(exc, Error);
+      assertEquals(exc.message, MSG);
+      assertEquals(exc.name, NAME);
+      assertEquals(exc.code, CODE);
+      assertEquals(exc.toString(), STR);
+      assertEquals(`${exc}`, STR);
+      assertEquals(exc.valueOf(), CODE);
+      assertEquals(+exc, CODE);
+      assertStringIncludes(exc.helpUrl, URL);
+      assertEquals(exc.cause, CAUSE);
+      assertEquals(exc.data, DATA);
+    });
+  });
+});

--- a/dispose/exceptions/object_disposed_exception.ts
+++ b/dispose/exceptions/object_disposed_exception.ts
@@ -1,0 +1,156 @@
+/**
+ * @copyright 2020-2024 integereleven. All rights reserved. MIT license.
+ * @file This file exports the ObjectDisposedException and its related data type.
+ */
+
+import { type BaseExceptionData, InvalidException } from '@kz/core/exceptions';
+
+/**
+ * Additional, related data for the {@link ObjectDisposedException} class.
+ *
+ * @example
+ * ```ts
+ * import { assertEquals } from '@std/assert';
+ * import type { ObjectDisposedExceptionData } from './object_disposed_exception.ts';
+ *
+ * const data: ObjectDisposedExceptionData = {
+ *   objectName: 'foo',
+ * };
+ *
+ * assertEquals(data.objectName, 'foo');
+ * ```
+ */
+export type ObjectDisposedExceptionData = BaseExceptionData<{
+  /**
+   * The name of the disposed object.
+   */
+  objectName?: string;
+}>;
+
+/**
+ * An exception raised when an argument has the correct type but has an invalid value.
+ *
+ * @param T - The type of the additional, relevant data for the exception.
+ *
+ * @example No arguments - default message
+ * ```ts
+ * import { assertEquals } from '@std/assert';
+ * import { ObjectDisposedException } from './object_disposed_exception.ts';
+ *
+ * const exception = new ObjectDisposedException();
+ *
+ * assertEquals(exception.message, 'An operation was attempted on a disposed object.');
+ * ```
+ *
+ * @example With provided message
+ * ```ts
+ * import { assertEquals } from '@std/assert';
+ * import { ObjectDisposedException } from './object_disposed_exception.ts';
+ *
+ * const exception = new ObjectDisposedException('An object is disposed, but an operation was attempted.');
+ *
+ * assertEquals(exception.message, 'An object is disposed, but an operation was attempted.');
+ * ```
+ *
+ * @example With provided relevant data
+ * ```ts
+ * import { assertEquals } from '@std/assert';
+ * import { ObjectDisposedException } from './object_disposed_exception.ts';
+ *
+ * const exception = new ObjectDisposedException({ objectName: 'foo' });
+ *
+ * assertEquals(exception.message, 'An operation was attempted on a disposed object, foo');
+ * ```
+ *
+ * @example With provided message and relevant data
+ * ```ts
+ * import { assertEquals } from '@std/assert';
+ * import { ObjectDisposedException } from './object_disposed_exception.ts';
+ *
+ * const exception = new ObjectDisposedException('An object is disposed, but an operation was attempted.', { objectName: 'foo' });
+ *
+ * assertEquals(exception.message, 'An object is disposed, but an operation was attempted.');
+ * ```
+ */
+export class ObjectDisposedException<
+  T extends ObjectDisposedExceptionData = ObjectDisposedExceptionData,
+> extends InvalidException<T> {
+  /**
+   * Creates a new instance of the `ArgumentException` class with the default message description.
+   */
+  constructor();
+
+  /**
+   * Creates a new instance of the `ArgumentException` class with the specified message description.
+   *
+   * @param message The exception message description.
+   */
+  constructor(message: string);
+
+  /**
+   * Creates a new instance of the `ArgumentException` class with the specified relevant data, resulting in a generated message description.
+   *
+   * @param data The relevant data for the exception.
+   */
+  constructor(data: T);
+
+  /**
+   * Creates a new instance of the `ArgumentException` class with the specified message description and additional, relevant data.
+   *
+   * @param message The exception message description.
+   * @param data The additional, relevant data for the exception.
+   */
+  constructor(message: string, data: T);
+
+  /**
+   * @ignore implementation
+   */
+  constructor(messageOrData: string | T = DEFAULT_MESSAGE, data: T = {} as T) {
+    let message: string;
+
+    if (typeof messageOrData === 'string') {
+      message = messageOrData;
+    } else {
+      data = messageOrData;
+      message = createMessageFromData(data);
+    }
+
+    message = message || DEFAULT_MESSAGE;
+
+    super(message, data);
+  }
+
+  /**
+   * The exception code.
+   *
+   * @example
+   * ```ts
+   * import { assertEquals } from '@std/assert';
+   * import { ObjectDisposedException } from './object_disposed_exception.ts';
+   *
+   * const exception = new ObjectDisposedException('An object is disposed, but an operation was attempted.');
+   *
+   * assertEquals(exception.code, 64);
+   * ```
+   */
+  public code = 0x40;
+}
+
+/**
+ * The default message for the {@link ObjectDisposedException} exception.
+ */
+const DEFAULT_MESSAGE = 'An operation was attempted on a disposed object.';
+
+/**
+ * Creates a message from the exception data.
+ *
+ * @param data The exception data.
+ * @returns The exception message.
+ */
+function createMessageFromData(data: ObjectDisposedExceptionData): string {
+  const { objectName } = data;
+
+  return objectName
+    ? `An operation was attempted on a disposed object, ${objectName}.`
+    : DEFAULT_MESSAGE;
+}

--- a/dispose/mod.ts
+++ b/dispose/mod.ts
@@ -1,0 +1,15 @@
+/**
+ * @copyright 2020-2024 integereleven. All rights reserved. MIT license.
+ *
+ * The `@kz/core/dispose` module provides types and features for using and disposing of managed resources.
+ *
+ * @module dispose
+ */
+
+export * from './exceptions/mod.ts';
+export * from './types/mod.ts';
+export { AbstractDisposable } from './abstract_disposable.ts';
+export { assertNotDisposed } from './assert_not_disposed.ts';
+export { DisposablePool } from './disposable_pool.ts';
+export { dispose } from './dispose.ts';
+export { using, usingAsync } from './using.ts';

--- a/dispose/types/interfaces.ts
+++ b/dispose/types/interfaces.ts
@@ -1,0 +1,51 @@
+/**
+ * @copyright 2020-2024 integereleven. All rights reserved. MIT license.
+ * @file Interfaces for the module.
+ */
+
+/**
+ * Provides a mechanism to dispose of resources associated with the object.
+ *
+ * @example
+ * ```ts
+ * import { assert } from '@std/assert';
+ * import { ObjectDisposedException } from '../exceptions/mod.ts';
+ *
+ * import type { IDisposable } from './interfaces.ts';
+ *
+ * class MyClass implements IDisposable {
+ *   private _isDisposed = false;
+ *
+ *   public dispose(): void {
+ *     if (this._isDisposed) {
+ *       throw new ObjectDisposedException('MyClass');
+ *     }
+ *
+ *     this._isDisposed = true;
+ *   }
+ *
+ *   public get isDisposed(): boolean {
+ *     return this._isDisposed;
+ *   }
+ * }
+ *
+ * const myObject = new MyClass();
+ *
+ * assert(!myObject.isDisposed);
+ *
+ * myObject.dispose();
+ *
+ * assert(myObject.isDisposed);
+ * ```
+ */
+export interface IDisposable {
+  /**
+   * Dispose of resources associated with the current instance.
+   */
+  dispose(): void;
+
+  /**
+   * A value indicating whether the current instance has been disposed.
+   */
+  isDisposed: boolean;
+}

--- a/dispose/types/mod.ts
+++ b/dispose/types/mod.ts
@@ -1,0 +1,6 @@
+/**
+ * @copyright 2020-2024 integereleven. All rights reserved. MIT license.
+ * @file Exports public types from the module.
+ */
+
+export type { IDisposable } from './interfaces.ts';

--- a/dispose/using.test.ts
+++ b/dispose/using.test.ts
@@ -1,0 +1,64 @@
+/**
+ * @copyright 2020-2024 integereleven. All rights reserved. MIT license.
+ * @file This file tests the using and usingAsync functions.
+ */
+
+import { describe, it } from '@std/testing/bdd';
+import { assert } from '@std/assert';
+
+import { type IDisposable, using, usingAsync } from './mod.ts';
+
+class Basic implements IDisposable {
+  constructor(public name: string) {}
+
+  isDisposed = false;
+
+  dispose(): void {
+    this.isDisposed = true;
+  }
+}
+
+class Async implements IDisposable {
+  constructor(public name: string) {}
+
+  isDisposed = false;
+
+  async run(): Promise<void> {
+    await new Promise(function (resolve): void {
+      setTimeout(resolve, 1000);
+    });
+  }
+
+  dispose(): void {
+    this.isDisposed = true;
+  }
+}
+
+describe('using', () => {
+  describe('using(disposable, callback', () => {
+    const disposable = new Basic('A');
+
+    it('should dispose after callback', () => {
+      using(disposable, (d) => {
+        assert(!d.isDisposed);
+        assert(d.name === 'A');
+      });
+
+      assert(disposable.isDisposed);
+    });
+  });
+
+  describe('usingAsync(disposable, callback)', () => {
+    const disposable = new Async('A');
+
+    it('should dispose after callback', async () => {
+      await usingAsync(disposable, async (d) => {
+        assert(!d.isDisposed);
+        await d.run();
+        assert(d.name === 'A');
+      });
+
+      assert(disposable.isDisposed);
+    });
+  });
+});

--- a/dispose/using.ts
+++ b/dispose/using.ts
@@ -1,0 +1,101 @@
+/**
+ * @copyright 2020-2024 integereleven. All rights reserved. MIT license.
+ * @file Exports the using and usingAsync functions.
+ */
+
+import { dispose } from './dispose.ts';
+
+import type { IDisposable } from './types/mod.ts';
+
+/**
+ * Performs a callback function with the provided {@link IDisposable} disposing on completion, returning the result of the callback.
+ *
+ * @param disposable - The {@link IDisposable} object to use.
+ * @param callback - The function to perform with the `disposable`.
+ * @returns The result of the `callback` function.
+ *
+ * @example
+ * ```ts
+ * import { assert } from '@std/assert';
+ * import { using } from './using.ts';
+ * import type { IDisposable } from './types/mod.ts';
+ *
+ * class Basic implements IDisposable {
+ *    constructor(public name: string) {}
+ *
+ *   isDisposed = false;
+ *
+ *   dispose(): void {
+ *     this.isDisposed = true;
+ *   }
+ * }
+ *
+ * const disposable = new Basic('A');
+ *
+ * using(disposable, (d) => {
+ *   assert(!d.isDisposed);
+ * });
+ *
+ * assert(disposable.isDisposed);
+ * ```
+ */
+export function using<T extends IDisposable, R>(
+  disposable: T,
+  callback: (disposable: T) => R,
+): R {
+  try {
+    return callback(disposable);
+  } finally {
+    dispose(disposable);
+  }
+}
+
+/**
+ * Asynchronously performs a callback function with the provided {@link IDisposable} disposing on completion, returning the result of the callback.
+ *
+ * @param disposable - The {@link IDisposable} object to use.
+ * @param callback - The function to perform with the `disposable`.
+ * @returns The result of the `callback` function.
+ *
+ * @example
+ * ```ts
+ * import { assert } from '@std/assert';
+ * import { usingAsync } from './using.ts';
+ * import type { IDisposable } from './types/mod.ts';
+ *
+ * class Async implements IDisposable {
+ *    constructor(public name: string) {}
+ *
+ *    isDisposed = false;
+ *
+ *   async run(): Promise<void> {
+ *     await new Promise(function (resolve): void {
+ *       setTimeout(resolve, 1000);
+ *     });
+ *   }
+ *
+ *   dispose(): void {
+ *     this.isDisposed = true;
+ *   }
+ * }
+ *
+ * const disposable = new Async('A');
+ *
+ * await usingAsync(disposable, async (d) => {
+ *   assert(!d.isDisposed);
+ *   await d.run();
+ * });
+ *
+ * assert(disposable.isDisposed);
+ * ```
+ */
+export async function usingAsync<T extends IDisposable, R>(
+  disposable: T,
+  callback: (disposable: T) => Promise<R>,
+): Promise<R> {
+  try {
+    return await callback(disposable);
+  } finally {
+    dispose(disposable);
+  }
+}

--- a/observe/mod.ts
+++ b/observe/mod.ts
@@ -1,0 +1,12 @@
+/**
+ * @copyright 2020-2024 integereleven. All rights reserved. MIT license.
+ *
+ * The `@kz/core/observe` module provides types and features for implementing the observer pattern.
+ *
+ * @module observe
+ */
+
+export * from './types/mod.ts';
+export { TBaseObservable } from './t_base_observable.ts';
+export { TAbstractObserver } from './t_abstract_observer.ts';
+export { TSubscription } from './t_subscription.ts';

--- a/observe/module.test.ts
+++ b/observe/module.test.ts
@@ -1,0 +1,160 @@
+/**
+ * @copyright 2020-2024 integereleven. All rights reserved. MIT license.
+ * @file This file tests the features of the module.
+ */
+
+import { describe, it } from '@std/testing/bdd';
+import { assertSpyCalls, spy } from '@std/testing/mock';
+import { assertEquals } from '@std/assert';
+
+import { TAbstractObserver, TBaseObservable } from './mod.ts';
+
+import type { IDisposable } from '../dispose/mod.ts';
+
+interface ILocation {
+  lat: number;
+  lon: number;
+}
+
+class LocationReporter extends TBaseObservable<ILocation> {
+  public reportLocation(location: ILocation): void {
+    try {
+      if (location.lat < -90 || location.lat > 90) {
+        throw new Error('Invalid latitude');
+      }
+
+      this.publish(location);
+    } catch (error) {
+      this.onError(error);
+    }
+  }
+}
+
+class LocationTracker extends TAbstractObserver<ILocation> {
+  protected _locations: ILocation[] = [];
+
+  public get locations(): ILocation[] {
+    return this._locations;
+  }
+
+  public next(location: ILocation): void {
+    if (this.subscription && this.subscription.isDisposed) return;
+
+    this._locations.push(location);
+  }
+
+  public error(error: Error): void {
+    console.log(error.message);
+  }
+}
+
+describe('observe', () => {
+  describe('TBaseObservable', () => {
+    const reporter = new LocationReporter();
+    const trackerOrg1 = new LocationTracker();
+    const trackerOrg2 = new LocationTracker();
+    const trackerOrg3 = new LocationTracker();
+    let sub1: IDisposable;
+    let sub2: IDisposable;
+    let sub3: IDisposable;
+
+    it('should subscribe observers', () => {
+      sub1 = reporter.subscribe(trackerOrg1);
+      sub2 = reporter.subscribe(trackerOrg2);
+      sub3 = reporter.subscribe(trackerOrg3);
+
+      assertEquals(sub1.isDisposed, false);
+      assertEquals(sub2.isDisposed, false);
+      assertEquals(sub3.isDisposed, false);
+    });
+
+    it('should publish values to all subscribed observers', () => {
+      const location = { lat: 37.7749, lon: 122.4194 };
+
+      reporter.reportLocation(location);
+
+      assertEquals(trackerOrg1.locations.length, 1);
+      assertEquals(trackerOrg2.locations.length, 1);
+      assertEquals(trackerOrg3.locations.length, 1);
+    });
+
+    it('should notify of error', () => {
+      const consoleSpy = spy(console, 'log');
+
+      reporter.reportLocation({ lat: 100, lon: 100 });
+
+      assertSpyCalls(consoleSpy, 3);
+
+      consoleSpy.restore();
+    });
+
+    it('should complete', () => {
+      reporter.complete();
+
+      assertEquals(trackerOrg1.locations.length, 1);
+      assertEquals(trackerOrg2.locations.length, 1);
+      assertEquals(trackerOrg3.locations.length, 1);
+      assertEquals(sub1!.isDisposed, true);
+      assertEquals(sub2!.isDisposed, true);
+      assertEquals(sub3!.isDisposed, true);
+    });
+  });
+
+  describe('TAbstractObserver', () => {
+    const reporter = new LocationReporter();
+    const trackerOrg1 = new LocationTracker();
+    const trackerOrg2 = new LocationTracker();
+    const trackerOrg3 = new LocationTracker();
+    let sub1: IDisposable;
+    let sub2: IDisposable;
+    let sub3: IDisposable;
+
+    it('should subscribe observers', () => {
+      sub1 = trackerOrg1.subscribe(reporter);
+      sub2 = trackerOrg2.subscribe(reporter);
+      sub3 = trackerOrg3.subscribe(reporter);
+
+      assertEquals(sub1.isDisposed, false);
+      assertEquals(sub2.isDisposed, false);
+      assertEquals(sub3.isDisposed, false);
+    });
+
+    it('should unsubscribe from observable', () => {
+      trackerOrg1.unsubscribe();
+
+      assertEquals(sub1!.isDisposed, false);
+      assertEquals(sub2!.isDisposed, false);
+      assertEquals(sub3!.isDisposed, false);
+
+      reporter.reportLocation({ lat: 37.7749, lon: 122.4194 });
+
+      assertEquals(trackerOrg1.locations.length, 0);
+      assertEquals(trackerOrg2.locations.length, 1);
+      assertEquals(trackerOrg3.locations.length, 1);
+
+      trackerOrg2.unsubscribe();
+
+      assertEquals(sub1!.isDisposed, false);
+      assertEquals(sub2!.isDisposed, false);
+      assertEquals(sub3!.isDisposed, false);
+
+      reporter.reportLocation({ lat: 37.7749, lon: 122.4194 });
+
+      assertEquals(trackerOrg1.locations.length, 0);
+      assertEquals(trackerOrg2.locations.length, 1);
+      assertEquals(trackerOrg3.locations.length, 2);
+
+      trackerOrg3.complete();
+
+      assertEquals(sub1!.isDisposed, true);
+      assertEquals(sub2!.isDisposed, true);
+      assertEquals(sub3!.isDisposed, true);
+
+      reporter.reportLocation({ lat: 37.7749, lon: 122.4194 });
+
+      assertEquals(trackerOrg1.locations.length, 0);
+      assertEquals(trackerOrg2.locations.length, 1);
+      assertEquals(trackerOrg3.locations.length, 2);
+    });
+  });
+});

--- a/observe/t_abstract_observer.ts
+++ b/observe/t_abstract_observer.ts
@@ -1,0 +1,60 @@
+/**
+ * @copyright 2020-2024 integereleven. All rights reserved. MIT license.
+ * @file Exports the AbstractObserver abstract class.
+ */
+
+import type { IDisposable } from '../dispose/mod.ts';
+import type { TObservable, TObserver } from './types/mod.ts';
+
+/**
+ * A base abstract implementation for the {@link TObserver} interface.
+ *
+ * @typeParam T - The type of the value being observed.
+ */
+export abstract class TAbstractObserver<T> implements TObserver<T> {
+  /**
+   * The subscription instance that can be used to unsubscribe the observer from the observable.
+   */
+  protected subscription?: IDisposable;
+
+  /**
+   * Receives a value from the observable.
+   *
+   * @param value - The value being observed.
+   */
+  public abstract next(value: T): void;
+
+  /**
+   * Receives an error from the observable.
+   *
+   * @param error - The error that occurred.
+   */
+  public abstract error(error: Error): void;
+
+  /**
+   * Receives a completion notification from the observable.
+   */
+  public complete(): void {
+    this.unsubscribe();
+  }
+
+  /**
+   * Subscribes the observer to the specified observable.
+   *
+   * @param observable The observable to subscribe to.
+   */
+  public subscribe(observable: TObservable<T>): IDisposable {
+    return this.subscription = observable.subscribe(this);
+  }
+
+  /**
+   * Unsubscribes the observer from the observable.
+   */
+  public unsubscribe(): void {
+    const { subscription } = this;
+
+    if (subscription) {
+      subscription.dispose();
+    }
+  }
+}

--- a/observe/t_base_observable.ts
+++ b/observe/t_base_observable.ts
@@ -1,0 +1,72 @@
+/**
+ * @copyright 2020-2024 integereleven. All rights reserved. MIT license.
+ * @file Exports the AbstractObservable abstract class.
+ */
+
+import { TSubscription } from './t_subscription.ts';
+
+import type { IDisposable } from '../dispose/mod.ts';
+import type { TObservable, TObserver } from './types/mod.ts';
+
+/**
+ * A base implementation for the {@link TObservable} interface.
+ *
+ * @typeParam T - The type of the value being observed.
+ */
+export class TBaseObservable<T> implements TObservable<T> {
+  /**
+   * The observers that are subscribed to the observable.
+   */
+  protected observers: TObserver<T>[] = [];
+
+  /**
+   * Subscribes an observer to the observable, returning an {@link IDisposable} instance that can be used to unsubscribe the observer.
+   *
+   * @param observer The observer to subscribe.
+   * @returns An {@link IDisposable} instance that can be used to unsubscribe the observer.
+   */
+  public subscribe(observer: TObserver<T>): IDisposable {
+    this.observers.push(observer);
+
+    return new TSubscription(this.observers, observer);
+  }
+
+  /**
+   * Pushes a value to all subscribed observers.
+   *
+   * @param value The value to push to the subscribed observers.
+   */
+  public publish(value: T): void {
+    const { observers } = this;
+
+    for (const observer of observers) {
+      observer.next(value);
+    }
+  }
+
+  /**
+   * Notifies all subscribed observers that an error has occurred.
+   *
+   * @param error The error that occurred.
+   */
+  protected onError(error: Error): void {
+    const { observers } = this;
+
+    for (const observer of observers) {
+      observer.error(error);
+    }
+  }
+
+  /**
+   * Notifies all subscribed observers that the observable has completed.
+   */
+  public complete(): void {
+    const { observers } = this;
+
+    for (const observer of observers) {
+      observer.complete();
+    }
+
+    observers.length = 0;
+  }
+}

--- a/observe/t_subscription.ts
+++ b/observe/t_subscription.ts
@@ -1,0 +1,48 @@
+/**
+ * @copyright 2020-2024 integereleven. All rights reserved. MIT license.
+ * @file Exports the TSubscription class.
+ */
+
+import type { IDisposable } from '../dispose/mod.ts';
+import type { TObserver } from './types/mod.ts';
+
+/**
+ * Provides a mechanism to unsubscribe an observer from an observable.
+ *
+ * @typeParam T - The type of the value being observed.
+ */
+export class TSubscription<T> implements IDisposable {
+  /**
+   * Initializes a new instance of the {@link TSubscription} class.
+   *
+   * @param observers - The observers that are subscribed to the observable.
+   * @param observer - The current observer to subscribe.
+   */
+  constructor(
+    protected observers: TObserver<T>[],
+    protected observer: TObserver<T>,
+  ) {
+  }
+
+  /**
+   * Whether the subscription has been disposed.
+   */
+  public get isDisposed(): boolean {
+    const { observers } = this;
+
+    return !observers.length;
+  }
+
+  /**
+   * Disposes the subscription, unsubscribing the observer from the observable.
+   */
+  public dispose(): void {
+    const { observers } = this;
+
+    const index = observers.indexOf(this.observer);
+
+    if (index >= 0) {
+      observers.splice(index, 1);
+    }
+  }
+}

--- a/observe/types/interfaces.ts
+++ b/observe/types/interfaces.ts
@@ -1,0 +1,58 @@
+/**
+ * @copyright 2020-2024 integereleven. All rights reserved. MIT license.
+ * @file Interfaces for the module. For type aliases see ./type-aliases.ts.
+ */
+
+import type { IDisposable } from '../../dispose/mod.ts';
+
+/**
+ * Provides a mechanism to push notifications to subscribed {@link TObserver} instances.
+ *
+ * @typeParam T - The type of the value being observed.
+ */
+export interface TObservable<T> {
+  /**
+   * Pushes a value to all subscribed observers.
+   *
+   * @param value - The value to push to the subscribed observers.
+   */
+  publish(value: T): void;
+
+  /**
+   * Subscribes an observer to the observable, returning an {@link IDisposable} instance that can be used to unsubscribe the observer.
+   *
+   * @param observer - The observer to subscribe.
+   */
+  subscribe(observer: TObserver<T>): IDisposable;
+
+  /**
+   * Notifies all subscribed observers that the observable has completed.
+   */
+  complete(): void;
+}
+
+/**
+ * Provides a mechanism to receive notifications from an {@link TObservable} instance.
+ *
+ * @typeParam T - The type of the value being observed.
+ */
+export interface TObserver<T> {
+  /**
+   * Receives a value from the observable.
+   *
+   * @param value - The value being observed.
+   */
+  next(value: T): void;
+
+  /**
+   * Receives an error from the observable.
+   *
+   * @param error - The error that occurred.
+   */
+  error(error: Error): void;
+
+  /**
+   * Receives a completion notification from the observable.
+   */
+  complete(): void;
+}

--- a/observe/types/mod.ts
+++ b/observe/types/mod.ts
@@ -1,0 +1,6 @@
+/**
+ * @copyright 2020-2024 integereleven. All rights reserved. MIT license.
+ * @file Exports public types from the module.
+ */
+
+export type { TObservable, TObserver } from './interfaces.ts';


### PR DESCRIPTION
Migrates both dispose and observe sub-modules from the `core` package.

Resolves #1 and #2.